### PR TITLE
Refactor: Remove redundant comment for telefone update

### DIFF
--- a/api/scripts/add_cpf_telefone.js
+++ b/api/scripts/add_cpf_telefone.js
@@ -10,7 +10,6 @@ async function run() {
     { $set: { cpf: "" } }
   );
 
-  // Set telefone to empty string where missing or null
   const resTel = await col.updateMany(
     { $or: [{ telefone: { $exists: false } }, { telefone: null }] },
     { $set: { telefone: "" } }


### PR DESCRIPTION
Eliminate unnecessary comment regarding setting telefone to an empty string, improving code clarity.